### PR TITLE
add protocol constants to py interface file

### DIFF
--- a/pyliblo3/_liblo.pyi
+++ b/pyliblo3/_liblo.pyi
@@ -1,4 +1,8 @@
 
+UDP = 1
+UNIX = 2
+TCP = 4
+
 class Callback:
     def __init__(self, func: Callable, user_data: Any): ...
 


### PR DESCRIPTION
all is in the title, this way when you import UDP, UNIX or TCP constants, IDE can know what it is.

